### PR TITLE
Further explain layout of fixtures in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # OCFL Test Fixtures
 
-All fixtures are drafts for a proposed 1.0 release of OCFL. Everything in this repository is organized by OCFL version number as the top-level directory. 
+All fixtures are drafts for a proposed 1.0 release of OCFL. Everything in this repository is organized by OCFL version number as the top-level directory.
 
 ## OCFL v1.0
 
-With the `1.0` directory there is:
-
-### `content`
-
-Data that comprises sets of object content arranged version directories in order to test the construction of OCFL objects and their subsequent extraction. Each fixture directory contains a readme file describing the features of the fixture.
+Within the `1.0` directory there is:
 
 ### `objects`
 
-Example good OCFL objects.
+This directory contains valid OCFL objects. Each directory is the OCFL object root of the valid object.
+
+### `content`
+
+This directory contains content that can be used to test the construction of OCFL objects, as well as the subsequent extraction of data from OCFL objects. Each fixture in this directory contains a short README file describing the features of the fixture.
+
+Some of these fixtures correspond to a valid OCFL object provided in the `objects` directory. These correspond by name. For example, `content/spec-ex-full` maps to `objects/spec-ex-full`, and `content/cf1` maps to `objects/of1`.
 
 ### `bad_objects`
 
-Example bad OCFL objects. Idea is to name the object directories `badXX_english_reason` where `XX` just keeps a sequence number and `english_reason` is a short explanation of why the object is bad. Then, there can be a corresponding `badXX_english_reason.json` which has details of what errors the validator should find.
+This directory contains invalid OCFL objects. They are named in the form `badXX_english_reason` where `XX` is just a sequence number, and `english_reason` is a short explanation of why the object is bad. Some fixtures have a corresponding `badXX_english_reason.json` which contains details of the errors that the validator should find.
+


### PR DESCRIPTION
Cleans up readme language, text wrapping, and notes the relationship
between some fixtures that are represented in both the objects and
content directories.